### PR TITLE
Remove nodeId as a parameter from open_orchestra_base_node_preview

### DIFF
--- a/BaseBundle/Resources/config/parameters.yml
+++ b/BaseBundle/Resources/config/parameters.yml
@@ -1,2 +1,2 @@
 parameters:
-    open_orchestra_base.preview_route_pattern: /preview/{nodeId}/{aliasId}/{token}
+    open_orchestra_base.preview_route_pattern: /preview/{aliasId}/{token}


### PR DESCRIPTION
[OO-BCBREAK] Remove a useless parameter on open_orchestra_base_node_preview route
https://github.com/open-orchestra/open-orchestra-base-bundle/pull/117
https://github.com/open-orchestra/open-orchestra-front-bundle/pull/202
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1971